### PR TITLE
Update apple dependencies to use newer swiftlang location

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             targets: ["ScreamURITemplateMacros"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax", from: "601.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
The swift-docc-plugin and swift-syntax dependencies have their URLs update to the swiftlang location (See: https://www.swift.org/blog/swiftlang-github/).  

Unfortunately, using the older "apple" package URL will conflict with other packages in that reference the "swiftlang" version of the URL, since they both refer to what is effectively the same package.  I think updating to "swiftlang" is the right thing to do here since that will hopefully be the enduring location.   I have an immediate need to resolve this conflict in a project so I create a fork to get moving, but wanted to share back the change in case it was desired.  Thank you for your sharing your work.