### PR TITLE
Parsing performance improvements

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,7 +8,8 @@ opt_in_rules:
 included:
 
 excluded:
-  .build
+  - .build
+  - Benchmarks/.build
 
 trailing_comma:
   mandatory_comma: true

--- a/Benchmarks/Sources/ScreamURITemplateBenchmark/main.swift
+++ b/Benchmarks/Sources/ScreamURITemplateBenchmark/main.swift
@@ -33,6 +33,15 @@ private let benchmarks = [
     Benchmark(
         name: "long-literal",
         template: "https://example.com/" + String(repeating: "path-segment/", count: 20) + "{value}"),
+    Benchmark(
+        name: "many-components",
+        template: String(repeating: "literal-{value}", count: 10)),
+    Benchmark(
+        name: "many-variables",
+        template: "{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}"),
+    Benchmark(
+        name: "many-percent-triplets",
+        template: String(repeating: "%20", count: 40) + "{value}"),
 ]
 
 private let iterations = CommandLine.arguments.dropFirst().first.flatMap(Int.init) ?? 200_000

--- a/Sources/ScreamURITemplate/Internal/Components.swift
+++ b/Sources/ScreamURITemplate/Internal/Components.swift
@@ -14,25 +14,42 @@
 
 import Foundation
 
-typealias ComponentBase = Sendable
+enum Component {
+    case literal(LiteralComponent)
+    case percentEncodedLiteral(LiteralPercentEncodedTripletComponent)
+    case expression(ExpressionComponent)
 
-protocol Component: ComponentBase {
-    func expand(variables: TypedVariableProvider) throws(URITemplate.Error) -> String
-    var variableNames: [String] { get }
-    var level: URITemplate.Level { get }
-}
+    func expand(variables: TypedVariableProvider) throws(URITemplate.Error) -> String {
+        switch self {
+        case let .literal(component):
+            try component.expand(variables: variables)
+        case let .percentEncodedLiteral(component):
+            try component.expand(variables: variables)
+        case let .expression(component):
+            try component.expand(variables: variables)
+        }
+    }
 
-extension Component {
     var variableNames: [String] {
-        return []
+        switch self {
+        case .literal, .percentEncodedLiteral:
+            []
+        case let .expression(component):
+            component.variableNames
+        }
     }
 
     var level: URITemplate.Level {
-        return .level1
+        switch self {
+        case .literal, .percentEncodedLiteral:
+            .level1
+        case let .expression(component):
+            component.level
+        }
     }
 }
 
-struct LiteralComponent: Component {
+struct LiteralComponent {
     let literal: Substring
     init(_ string: Substring) {
         literal = string
@@ -47,7 +64,7 @@ struct LiteralComponent: Component {
     }
 }
 
-struct LiteralPercentEncodedTripletComponent: Component {
+struct LiteralPercentEncodedTripletComponent {
     let literal: Substring
     init(_ string: Substring) {
         literal = string
@@ -58,7 +75,7 @@ struct LiteralPercentEncodedTripletComponent: Component {
     }
 }
 
-struct ExpressionComponent: Component {
+struct ExpressionComponent {
     let expressionOperator: ExpressionOperator
     let variableList: [VariableSpec]
     let templatePosition: String.Index

--- a/Sources/ScreamURITemplate/Internal/Components.swift
+++ b/Sources/ScreamURITemplate/Internal/Components.swift
@@ -16,7 +16,7 @@ import Foundation
 
 enum Component {
     case literal(LiteralComponent)
-    case percentEncodedLiteral(LiteralPercentEncodedTripletComponent)
+    case percentEncodedLiteral(LiteralPercentEncodedComponent)
     case expression(ExpressionComponent)
 
     func expand(variables: TypedVariableProvider) throws(URITemplate.Error) -> String {
@@ -64,7 +64,7 @@ struct LiteralComponent {
     }
 }
 
-struct LiteralPercentEncodedTripletComponent {
+struct LiteralPercentEncodedComponent {
     let literal: Substring
     init(_ string: Substring) {
         literal = string

--- a/Sources/ScreamURITemplate/Internal/Components.swift
+++ b/Sources/ScreamURITemplate/Internal/Components.swift
@@ -77,20 +77,37 @@ struct LiteralPercentEncodedComponent {
 
 struct ExpressionComponent {
     let expressionOperator: ExpressionOperator
-    let variableList: [VariableSpec]
+    let variableList: VariableList
     let templatePosition: String.Index
 
     func expand(variables: TypedVariableProvider) throws(URITemplate.Error) -> String {
         let configuration = expressionOperator.expansionConfiguration()
-        do {
-            let expansions = try variableList.compactMap { variableSpec throws(URITemplate.Error) -> String? in
-                guard let value = variables[String(variableSpec.name)] else {
-                    return nil
-                }
-                do throws(FormatError) {
-                    return try value.formatForTemplateExpansion(variableSpec: variableSpec, expansionConfiguration: configuration)
-                } catch {
-                    throw URITemplate.Error(type: .expansionFailure, position: templatePosition, reason: "Failed expanding variable \"\(variableSpec.name)\": \(error.reason)")
+        func expansion(for variableSpec: VariableSpec) throws(URITemplate.Error) -> String? {
+            guard let value = variables[String(variableSpec.name)] else {
+                return nil
+            }
+            do throws(FormatError) {
+                return try value.formatForTemplateExpansion(variableSpec: variableSpec, expansionConfiguration: configuration)
+            } catch {
+                throw URITemplate.Error(type: .expansionFailure, position: templatePosition, reason: "Failed expanding variable \"\(variableSpec.name)\": \(error.reason)")
+            }
+        }
+
+        switch variableList {
+        case let .one(variableSpec):
+            guard let expansion = try expansion(for: variableSpec) else {
+                return ""
+            }
+            if let prefix = configuration.prefix {
+                return prefix + expansion
+            }
+            return expansion
+        case let .many(variableSpecs):
+            var expansions: [String] = []
+            expansions.reserveCapacity(variableSpecs.count)
+            for variableSpec in variableSpecs {
+                if let expansion = try expansion(for: variableSpec) {
+                    expansions.append(expansion)
                 }
             }
 
@@ -103,33 +120,43 @@ struct ExpressionComponent {
                 return prefix + joinedExpansions
             }
             return joinedExpansions
-        } catch let error as URITemplate.Error {
-            throw error
-        } catch {
-            // compactMap is not marked up for Typed Throws, the compiler therefore does not know that this is not possible
-            throw URITemplate.Error(type: .expansionFailure, position: templatePosition, reason: "Failed expanding variable: \(error.localizedDescription)")
         }
     }
 
     var variableNames: [String] {
-        return variableList.map { variableSpec in
-            return String(variableSpec.name)
+        switch variableList {
+        case let .one(variableSpec):
+            return [String(variableSpec.name)]
+        case let .many(variableSpecs):
+            return variableSpecs.map { variableSpec in
+                return String(variableSpec.name)
+            }
         }
     }
 
     var level: URITemplate.Level {
         // Check for modifiers (level 4)
-        for variableSpec in variableList {
+        switch variableList {
+        case let .one(variableSpec):
             switch variableSpec.modifier {
             case .none:
-                continue
+                break
             case .explode, .prefix:
                 return .level4
+            }
+        case let .many(variableSpecs):
+            for variableSpec in variableSpecs {
+                switch variableSpec.modifier {
+                case .none:
+                    continue
+                case .explode, .prefix:
+                    return .level4
+                }
             }
         }
 
         // Check for multiple variables (level 3)
-        if variableList.count > 1 {
+        if case .many = variableList {
             return .level3
         }
 

--- a/Sources/ScreamURITemplate/Internal/Scanner.swift
+++ b/Sources/ScreamURITemplate/Internal/Scanner.swift
@@ -89,8 +89,26 @@ struct Scanner {
         return expressionOperator
     }
 
-    private mutating func scanVariableList() throws(URITemplate.Error) -> [VariableSpec] {
-        var variableList: [VariableSpec] = []
+    private mutating func scanVariableList() throws(URITemplate.Error) -> VariableList {
+        let firstVariableName = try scanVariableName()
+        let firstModifier = try scanVariableModifier()
+        let firstVariableSpec = VariableSpec(name: firstVariableName, modifier: firstModifier)
+
+        guard currentIndex < utf8.endIndex else {
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Unterminated Expression")
+        }
+
+        switch utf8[currentIndex] {
+        case UTF8.CodeUnit.closeBrace:
+            currentIndex = utf8.index(after: currentIndex)
+            return .one(firstVariableSpec)
+        case UTF8.CodeUnit.comma:
+            currentIndex = utf8.index(after: currentIndex)
+        default:
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Unexpected Character in Expression")
+        }
+
+        var variableList = [firstVariableSpec]
         variableList.reserveCapacity(4)
 
         var complete = false
@@ -114,7 +132,7 @@ struct Scanner {
             }
         }
 
-        return variableList
+        return .many(variableList)
     }
 
     private mutating func scanVariableName() throws(URITemplate.Error) -> Substring {
@@ -183,26 +201,31 @@ struct Scanner {
             currentIndex = utf8.index(after: currentIndex)
             return .explode
         case UTF8.CodeUnit.colon:
-            currentIndex = utf8.index(after: currentIndex)
-            let endIndex = scanWhile { $0.isDecimalDigit() }
-            let lengthString = string[currentIndex..<endIndex]
-            if lengthString.isEmpty {
-                throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix length not specified")
-            }
-            if lengthString.first == "0" {
-                throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix length cannot begin with 0")
-            }
-            if lengthString.count > 4 {
-                throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix modifier length too large")
-            }
-            guard let length = Int(lengthString) else {
-                throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Cannot parse prefix modifier length")
-            }
-            currentIndex = endIndex
-            return .prefix(length: length)
+            return try scanPrefixModifier()
         default:
             return .none
         }
+    }
+
+    private mutating func scanPrefixModifier() throws(URITemplate.Error) -> VariableSpec.Modifier {
+        assert(utf8[currentIndex] == UTF8.CodeUnit.colon)
+        currentIndex = utf8.index(after: currentIndex)
+        let endIndex = scanWhile { $0.isDecimalDigit() }
+        let lengthString = string[currentIndex..<endIndex]
+        if lengthString.isEmpty {
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix length not specified")
+        }
+        if lengthString.first == "0" {
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix length cannot begin with 0")
+        }
+        if lengthString.count > 4 {
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Prefix modifier length too large")
+        }
+        guard let length = Int(lengthString) else {
+            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Cannot parse prefix modifier length")
+        }
+        currentIndex = endIndex
+        return .prefix(length: length)
     }
 
     private mutating func scanLiteralComponent() throws(URITemplate.Error) -> Component {

--- a/Sources/ScreamURITemplate/Internal/Scanner.swift
+++ b/Sources/ScreamURITemplate/Internal/Scanner.swift
@@ -235,24 +235,29 @@ struct Scanner {
         assert(utf8[currentIndex] == UTF8.CodeUnit.percent)
 
         let startIndex = currentIndex
+        var endIndex = startIndex
 
-        let secondIndex = utf8.index(after: startIndex)
-        guard secondIndex < utf8.endIndex else {
-            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "% must be percent-encoded in literal")
+        while endIndex < utf8.endIndex, utf8[endIndex] == UTF8.CodeUnit.percent {
+            let secondIndex = utf8.index(after: endIndex)
+            guard secondIndex < utf8.endIndex else {
+                throw URITemplate.Error(type: .malformedTemplate, position: endIndex, reason: "% must be percent-encoded in literal")
+            }
+
+            let thirdIndex = utf8.index(after: secondIndex)
+            guard thirdIndex < utf8.endIndex else {
+                throw URITemplate.Error(type: .malformedTemplate, position: endIndex, reason: "% must be percent-encoded in literal")
+            }
+
+            guard utf8[secondIndex].isHexDigit(),
+                  utf8[thirdIndex].isHexDigit() else {
+                throw URITemplate.Error(type: .malformedTemplate, position: endIndex, reason: "% must be percent-encoded in literal")
+            }
+
+            endIndex = utf8.index(after: thirdIndex)
         }
 
-        let thirdIndex = utf8.index(after: secondIndex)
-        guard thirdIndex < utf8.endIndex else {
-            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "% must be percent-encoded in literal")
-        }
-
-        guard utf8[secondIndex].isHexDigit(),
-              utf8[thirdIndex].isHexDigit() else {
-            throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "% must be percent-encoded in literal")
-        }
-
-        currentIndex = utf8.index(after: thirdIndex)
-        return .percentEncodedLiteral(LiteralPercentEncodedTripletComponent(string[startIndex...thirdIndex]))
+        currentIndex = endIndex
+        return .percentEncodedLiteral(LiteralPercentEncodedComponent(string[startIndex..<endIndex]))
     }
 
     private func scanWhile(_ predicate: (UTF8.CodeUnit) -> Bool) -> String.Index {

--- a/Sources/ScreamURITemplate/Internal/Scanner.swift
+++ b/Sources/ScreamURITemplate/Internal/Scanner.swift
@@ -91,6 +91,7 @@ struct Scanner {
 
     private mutating func scanVariableList() throws(URITemplate.Error) -> [VariableSpec] {
         var variableList: [VariableSpec] = []
+        variableList.reserveCapacity(4)
 
         var complete = false
         while !complete {

--- a/Sources/ScreamURITemplate/Internal/Scanner.swift
+++ b/Sources/ScreamURITemplate/Internal/Scanner.swift
@@ -52,7 +52,11 @@ struct Scanner {
         let expressionOperator = try scanExpressionOperator()
         let variableList = try scanVariableList()
 
-        return ExpressionComponent(expressionOperator: expressionOperator, variableList: variableList, templatePosition: expressionStartIndex)
+        return .expression(
+            ExpressionComponent(
+                expressionOperator: expressionOperator,
+                variableList: variableList,
+                templatePosition: expressionStartIndex))
     }
 
     private mutating func scanExpressionOperator() throws(URITemplate.Error) -> ExpressionOperator {
@@ -224,7 +228,7 @@ struct Scanner {
             throw URITemplate.Error(type: .malformedTemplate, position: currentIndex, reason: "Unexpected character")
         }
 
-        return LiteralComponent(string[startIndex..<endIndex])
+        return .literal(LiteralComponent(string[startIndex..<endIndex]))
     }
 
     private mutating func scanPercentEncodingComponent() throws(URITemplate.Error) -> Component {
@@ -248,7 +252,7 @@ struct Scanner {
         }
 
         currentIndex = utf8.index(after: thirdIndex)
-        return LiteralPercentEncodedTripletComponent(string[startIndex...thirdIndex])
+        return .percentEncodedLiteral(LiteralPercentEncodedTripletComponent(string[startIndex...thirdIndex]))
     }
 
     private func scanWhile(_ predicate: (UTF8.CodeUnit) -> Bool) -> String.Index {

--- a/Sources/ScreamURITemplate/Internal/VariableSpec.swift
+++ b/Sources/ScreamURITemplate/Internal/VariableSpec.swift
@@ -31,3 +31,8 @@ struct VariableSpec {
         return length
     }
 }
+
+enum VariableList {
+    case one(VariableSpec)
+    case many([VariableSpec])
+}

--- a/Sources/ScreamURITemplate/URITemplate.swift
+++ b/Sources/ScreamURITemplate/URITemplate.swift
@@ -42,6 +42,7 @@ public struct URITemplate {
     /// - Throws: `URITemplate.Error` with `type = .malformedTemplate` if the string is not a valid URI Template
     public init(string: String) throws(URITemplate.Error) {
         var components: [Component] = []
+        components.reserveCapacity(max(64, min(8, string.utf8.count / 8)))
         var scanner = Scanner(string: string)
         while !scanner.isComplete {
             try components.append(scanner.scanComponent())

--- a/Tests/ScreamURITemplateTests/Tests.swift
+++ b/Tests/ScreamURITemplateTests/Tests.swift
@@ -42,6 +42,22 @@ class Tests: XCTestCase {
         XCTAssertThrowsError(try URITemplate(string: "https://api.github.com/repos/%2"))
     }
 
+    func testAdjacentPercentEncodedTriplets() throws {
+        let template = try URITemplate(string: "%20%2F%3F{value}")
+        XCTAssertEqual(try template.process(variables: ["value": "expanded"]), "%20%2F%3Fexpanded")
+    }
+
+    func testIncompleteAdjacentPercentEncodedTriplet() throws {
+        let template = "%20%"
+        XCTAssertThrowsError(try URITemplate(string: template)) { error in
+            guard let templateError = error as? URITemplate.Error else {
+                XCTFail("Unexpected error type")
+                return
+            }
+            XCTAssertEqual(templateError.position, template.index(template.startIndex, offsetBy: 3))
+        }
+    }
+
     func testIncompletePercentEncodedVariableName() throws {
         for template in ["{var%", "{var%}", "{var%A}"] {
             XCTAssertThrowsError(try URITemplate(string: template)) { error in


### PR DESCRIPTION
**Before:**
iterations: 200000, samples: 7
typical: 0.723 ms / thousand iterations
operators: 0.665 ms / thousand iterations
unicode-literal: 0.536 ms / thousand iterations
long-literal: 0.839 ms / thousand iterations
many-components: 1.923 ms / thousand iterations
many-variables: 0.818 ms / thousand iterations
many-percent-triplets: 2.675 ms / thousand iterations

**After:**
iterations: 200000, samples: 7
typical: 0.330 ms / thousand iterations
operators: 0.380 ms / thousand iterations
unicode-literal: 0.287 ms / thousand iterations
long-literal: 0.734 ms / thousand iterations
many-components: 0.857 ms / thousand iterations
many-variables: 0.728 ms / thousand iterations
many-percent-triplets: 0.318 ms / thousand iterations